### PR TITLE
🧹 Janitor: Fix lints, formatting, and deprecations

### DIFF
--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -1,0 +1,1 @@
+- 2026-02-25: Replace deprecated 'io/ioutil' with 'io' and remove commented-out code.

--- a/api/selichoje.go
+++ b/api/selichoje.go
@@ -4,27 +4,17 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
 )
-
-// func main() {
-//     data, err := requestData()
-//     if err != nil {
-//         panic(err)
-//     }
-//     println(data)
-// }
 
 func Handler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("content-type", "text/plain")
 	w.Header().Set("Cache-Control", "max-age=3600")
 	data, err := requestData()
 	if err != nil {
-		w.WriteHeader(500)
-		fmt.Fprintln(w, err)
+		http.Error(w, err.Error(), 500)
 		return
 	}
 	w.WriteHeader(200)
@@ -58,31 +48,16 @@ func requestData() (string, error) {
 	req.Header.Add("Upgrade-Insecure-Requests", "1")
 	req.Header.Add("Referer", "https://www3.bcb.gov.br/novoselic/pesquisa-taxa-apurada.jsp")
 	buf := bytes.NewBufferString("filtro=%7B%22dataInicial%22%3A%2207%2F04%2F2021%22%2C%22dataFinal%22%3A%2207%2F04%2F2021%22%7D&parametrosOrdenacao=%5B%5D")
-	req.Body = rcwrap{r: buf}
+	req.Body = io.NopCloser(buf)
 	req.Method = "POST"
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", err
 	}
-	data, err := ioutil.ReadAll(res.Body)
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", err
 	}
-	err = res.Body.Close()
-	if err != nil {
-		return "", err
-	}
-	return string(data), err
-}
-
-type rcwrap struct {
-	r interface{}
-}
-
-func (r rcwrap) Read(b []byte) (int, error) {
-	return r.r.(io.Reader).Read(b)
-}
-
-func (rcwrap) Close() error {
-	return nil
+	return string(data), nil
 }

--- a/api/selichoje_test.go
+++ b/api/selichoje_test.go
@@ -5,22 +5,13 @@ import (
 )
 
 func TestParse(t *testing.T) {
-    const in = `Taxa Selic - Dados diários;Filtros aplicados: Data inicial: 07/04/2021 / Data final: 07/04/2021.;;;;;;;;;
+	const in = `Taxa Selic - Dados diários;Filtros aplicados: Data inicial: 07/04/2021 / Data final: 07/04/2021.;;;;;;;;;
 Data;Taxa (% a.a.);Fator diário;Financeiro (R$);Operações;Média;Mediana;Moda;Desvio padrão;Índice de curtose;
 07/04/2021;2,65;1,00010379;1.445.859.744.518,52;765;2,65;2,64;2,65;0,014;526,421;
 `
-    const expectedOut = "2.65"
-    out := getOnlySelic(in)
-    if (out != expectedOut) {
-        t.Errorf("expected '%s' got '%s'", expectedOut, out)
-    }
-    // Personal debugging
-    // data, err := requestData()
-    // if err != nil {
-    //     t.Error(err)
-    // }
-    // println("DATA:")
-    // println(data)
-    // println("PARSED:")
-    // println(getOnlySelic(data))
+	const expectedOut = "2.65"
+	out := getOnlySelic(in)
+	if out != expectedOut {
+		t.Errorf("expected '%s' got '%s'", expectedOut, out)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/lucasew/bcb-selic-hoje
 
-go 1.16
+go 1.23
 
 require github.com/davecgh/go-spew v1.1.1

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,9 @@
+[tools]
+go = "1.23.1"
+golangci-lint = "1.61.0"
+
+[tasks]
+lint = "golangci-lint run"
+fmt = "gofmt -w ."
+test = "go test ./..."
+build = "go build ./..."


### PR DESCRIPTION
## What Changed
- Added `mise.toml` to pin Go (1.23.1) and golangci-lint (1.61.0).
- Updated `go.mod` to Go 1.23.
- Replaced deprecated `io/ioutil` with `io`.
- Removed `rcwrap` struct and used `io.NopCloser` instead.
- Removed commented-out code in `api/selichoje.go` and `api/selichoje_test.go`.
- Simplified error handling in `Handler` using `http.Error`.
- Added journal entry to `.jules/janitor.md`.

## Why This Helps
- Modernizes the codebase by using current Go standard library practices.
- Removes dead code which reduces confusion.
- Ensures consistent tooling via `mise`.
- Fixes lint warnings and potential future build errors.

## Before/After
**Before:**
- Uses `io/ioutil`.
- Has commented-out code.
- Custom `rcwrap` struct.
- No `mise.toml`.

**After:**
- Uses `io`.
- Clean code without comments.
- Uses `io.NopCloser`.
- Has `mise.toml` with pinned tools.

## Verification
- Ran `mise run lint` (passed).
- Ran `mise run fmt` (passed).
- Ran `mise run test` (passed).


---
*PR created automatically by Jules for task [17256471932521650315](https://jules.google.com/task/17256471932521650315) started by @lucasew*