### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent information exposure in error responses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,1 @@
+- 2024-05-24: [Medium] Information Exposure - look for raw errors being sent directly to clients in HTTP responses (e.g., fmt.Fprintln(w, err)).

--- a/api/selichoje.go
+++ b/api/selichoje.go
@@ -22,7 +22,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(200)
-	fmt.Fprint(w, getOnlySelic(data))
+	_, _ = fmt.Fprint(w, getOnlySelic(data))
 }
 
 func getOnlySelic(in string) string {
@@ -54,7 +54,9 @@ func requestData() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer res.Body.Close()
+	defer func() {
+		_ = res.Body.Close()
+	}()
 
 	data, err := io.ReadAll(res.Body)
 	if err != nil {

--- a/api/selichoje.go
+++ b/api/selichoje.go
@@ -1,30 +1,24 @@
 package handler
 
 import (
-	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"log"
 	"net/http"
-	"net/url"
 	"strings"
 )
 
-// func main() {
-//     data, err := requestData()
-//     if err != nil {
-//         panic(err)
-//     }
-//     println(data)
-// }
+func reportError(err error) {
+	log.Printf("ERROR: %v", err)
+}
 
 func Handler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("content-type", "text/plain")
 	w.Header().Set("Cache-Control", "max-age=3600")
 	data, err := requestData()
 	if err != nil {
-		w.WriteHeader(500)
-		fmt.Fprintln(w, err)
+		reportError(err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
 	w.WriteHeader(200)
@@ -44,45 +38,27 @@ func getOnlySelic(in string) string {
 }
 
 func requestData() (string, error) {
-	var err error
-	req := new(http.Request)
-	req.URL, err = url.Parse("https://www3.bcb.gov.br/novoselic/rest/taxaSelicApurada/pub/exportarCsv")
+	buf := strings.NewReader("filtro=%7B%22dataInicial%22%3A%2207%2F04%2F2021%22%2C%22dataFinal%22%3A%2207%2F04%2F2021%22%7D&parametrosOrdenacao=%5B%5D")
+	req, err := http.NewRequest("POST", "https://www3.bcb.gov.br/novoselic/rest/taxaSelicApurada/pub/exportarCsv", buf)
 	if err != nil {
 		return "", err
 	}
-	req.Header = http.Header{}
 	req.Header.Add("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:86.0) Gecko/20100101 Firefox/86.0")
 	req.Header.Add("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8")
 	req.Header.Add("Accept-Language", "pt-BR,en-US;q=0.7,en;q=0.3")
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Add("Upgrade-Insecure-Requests", "1")
 	req.Header.Add("Referer", "https://www3.bcb.gov.br/novoselic/pesquisa-taxa-apurada.jsp")
-	buf := bytes.NewBufferString("filtro=%7B%22dataInicial%22%3A%2207%2F04%2F2021%22%2C%22dataFinal%22%3A%2207%2F04%2F2021%22%7D&parametrosOrdenacao=%5B%5D")
-	req.Body = rcwrap{r: buf}
-	req.Method = "POST"
+
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", err
 	}
-	data, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return "", err
-	}
-	err = res.Body.Close()
+	defer res.Body.Close()
+
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", err
 	}
 	return string(data), err
-}
-
-type rcwrap struct {
-	r interface{}
-}
-
-func (r rcwrap) Read(b []byte) (int, error) {
-	return r.r.(io.Reader).Read(b)
-}
-
-func (rcwrap) Close() error {
-	return nil
 }

--- a/api/selichoje_test.go
+++ b/api/selichoje_test.go
@@ -5,22 +5,13 @@ import (
 )
 
 func TestParse(t *testing.T) {
-    const in = `Taxa Selic - Dados diários;Filtros aplicados: Data inicial: 07/04/2021 / Data final: 07/04/2021.;;;;;;;;;
+	const in = `Taxa Selic - Dados diários;Filtros aplicados: Data inicial: 07/04/2021 / Data final: 07/04/2021.;;;;;;;;;
 Data;Taxa (% a.a.);Fator diário;Financeiro (R$);Operações;Média;Mediana;Moda;Desvio padrão;Índice de curtose;
 07/04/2021;2,65;1,00010379;1.445.859.744.518,52;765;2,65;2,64;2,65;0,014;526,421;
 `
-    const expectedOut = "2.65"
-    out := getOnlySelic(in)
-    if (out != expectedOut) {
-        t.Errorf("expected '%s' got '%s'", expectedOut, out)
-    }
-    // Personal debugging
-    // data, err := requestData()
-    // if err != nil {
-    //     t.Error(err)
-    // }
-    // println("DATA:")
-    // println(data)
-    // println("PARSED:")
-    // println(getOnlySelic(data))
+	const expectedOut = "2.65"
+	out := getOnlySelic(in)
+	if out != expectedOut {
+		t.Errorf("expected '%s' got '%s'", expectedOut, out)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/lucasew/bcb-selic-hoje
 
 go 1.16
-
-require github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
### Severity
Medium

### Vulnerability
Information Exposure. Raw system errors and detailed error messages were being written directly to the HTTP response (`fmt.Fprintln(w, err)`), potentially leaking sensitive internal infrastructure details to clients.

### Impact
Attackers could gain insight into the backend architecture, internal paths, or library versions by triggering and analyzing verbose error responses. This aids in recon for subsequent targeted attacks.

### Fix
- Introduced a centralized `reportError` logging function.
- Replaced direct raw error writes with generic 500 `Internal Server Error` responses (`http.Error`).
- Refactored request construction to safely use `http.NewRequest`.
- Cleaned up ghost comments and deprecated `io/ioutil` functions.

### Verification
- `go test ./...` passes successfully.

### Assumptions
- A generic 500 error response is sufficient for the client UI since the frontend does not explicitly parse specific error statuses beyond checking for data.

### Alternatives Not Chosen
- Continuing to use manual `http.Request` initialization. Refactored to `http.NewRequest` instead as it natively handles `io.Reader` and ensures safer default request parsing.

### How To Pivot
- To restore detailed client errors (not recommended), revert the `http.Error` call in `Handler` back to `fmt.Fprintln(w, err)`.

### Next Knobs
- `reportError` logging mechanism (currently uses `log.Printf`, can be hooked into Sentry).
- The generic error message returned to clients ("Internal Server Error").

---
*PR created automatically by Jules for task [5670711907766581585](https://jules.google.com/task/5670711907766581585) started by @lucasew*