### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent DoS via unbounded response read and missing HTTP timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vercel
+mise
+mise.local.toml

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,1 @@
+- 2026-03-12: Unbounded response reads (`ioutil.ReadAll`) and missing HTTP client timeouts can lead to memory exhaustion and resource hanging (DoS).

--- a/api/selichoje.go
+++ b/api/selichoje.go
@@ -4,19 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
-
-// func main() {
-//     data, err := requestData()
-//     if err != nil {
-//         panic(err)
-//     }
-//     println(data)
-// }
 
 func Handler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("content-type", "text/plain")
@@ -60,11 +52,14 @@ func requestData() (string, error) {
 	buf := bytes.NewBufferString("filtro=%7B%22dataInicial%22%3A%2207%2F04%2F2021%22%2C%22dataFinal%22%3A%2207%2F04%2F2021%22%7D&parametrosOrdenacao=%5B%5D")
 	req.Body = rcwrap{r: buf}
 	req.Method = "POST"
-	res, err := http.DefaultClient.Do(req)
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	res, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(io.LimitReader(res.Body, 1024*1024))
 	if err != nil {
 		return "", err
 	}

--- a/api/selichoje_test.go
+++ b/api/selichoje_test.go
@@ -14,13 +14,4 @@ Data;Taxa (% a.a.);Fator diário;Financeiro (R$);Operações;Média;Mediana;Moda
     if (out != expectedOut) {
         t.Errorf("expected '%s' got '%s'", expectedOut, out)
     }
-    // Personal debugging
-    // data, err := requestData()
-    // if err != nil {
-    //     t.Error(err)
-    // }
-    // println("DATA:")
-    // println(data)
-    // println("PARSED:")
-    // println(getOnlySelic(data))
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,6 @@
+[tools]
+go = "1.22.0"
+golangci-lint = "1.56.2"
+
+[tasks]
+test = "go test ./..."


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Prevent DoS via unbounded response read and missing HTTP timeout

**Severity:** MEDIUM
**Vulnerability:** Denial of Service (DoS) due to missing HTTP client timeout and unbounded response reading (`ioutil.ReadAll`).
**Impact:** A malicious or unexpectedly slow/large response from the upstream server could exhaust memory (OOM) or hang the connection indefinitely, leading to service disruption.
**Fix:** Introduced a custom `http.Client` with a strict 10-second timeout. Replaced `ioutil.ReadAll` with `io.ReadAll` and wrapped the response body in an `io.LimitReader` capped at 1MB to prevent memory exhaustion.
**Verification:** Ran `mise run test` to confirm tests pass, verifying normal logic works correctly within limits. 

Also addressed related housekeeping: removed ghost comments (commented-out debugging code) per retroactive memory violations and updated `.gitignore` to exclude `mise` directories.

**Assumptions:**
- The upstream response (Taxa Selic CSV) is expected to be extremely small (a few lines), so a 1MB limit is generously safe while strictly preventing unbounded memory allocation.
- A 10-second timeout is sufficient for the BCB API under normal conditions.
- Removing `main()` and test logging was safe as they were dead/commented-out blocks used only for personal debugging.

**Alternatives Not Chosen:**
- Creating a separate context with timeout (`context.WithTimeout`) and passing it to `http.NewRequestWithContext`. The chosen approach of configuring `http.Client{Timeout: ...}` is slightly simpler and covers the entire transaction, which is sufficient here.

**How To Pivot:**
- If the 10-second timeout is too short, increase `Timeout: 10 * time.Second` in `api/selichoje.go`.
- If the 1MB payload limit is incorrect or unnecessary, the limit size in `io.LimitReader(res.Body, 1024*1024)` can be adjusted or removed entirely if unbounded memory is acceptable (not recommended).

**Next Knobs:**
- `api/selichoje.go`: Adjust the HTTP timeout or the memory limit size (`1024*1024`).
- `.jules/sentinel.md`: The logged journal format/learning can be refined if needed.

---
*PR created automatically by Jules for task [605059189344988718](https://jules.google.com/task/605059189344988718) started by @lucasew*