### PR TITLE
📝 Docs: Document API handler and internal logic

### DIFF
--- a/api/selichoje.go
+++ b/api/selichoje.go
@@ -10,14 +10,9 @@ import (
 	"strings"
 )
 
-// func main() {
-//     data, err := requestData()
-//     if err != nil {
-//         panic(err)
-//     }
-//     println(data)
-// }
-
+// Handler is the Vercel serverless entrypoint for fetching the Selic rate.
+// It proxies the BCB API request, sets a 1-hour cache, and returns the rate as plain text.
+// Any upstream errors are returned as a 500 internal server error.
 func Handler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("content-type", "text/plain")
 	w.Header().Set("Cache-Control", "max-age=3600")
@@ -31,6 +26,10 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, getOnlySelic(data))
 }
 
+// getOnlySelic parses the BCB API CSV response to extract the Selic rate value.
+// It expects a precise 4-line format and extracts the 2nd column of the 3rd line.
+// The extracted rate has its comma converted to a dot for standard decimal formatting.
+// Returns an empty string if the input does not match the expected CSV shape.
 func getOnlySelic(in string) string {
 	lines := strings.Split(in, "\n")
 	if len(lines) != 4 {
@@ -43,6 +42,12 @@ func getOnlySelic(in string) string {
 	return strings.ReplaceAll(values[1], ",", ".")
 }
 
+// requestData queries the BCB API for the Selic rate.
+// It simulates a real browser request to bypass basic scraper protections.
+//
+// Limitations:
+// - It currently uses a hardcoded date (07/04/2021) due to a logic flaw.
+// - HTTP Client does not define a Timeout.
 func requestData() (string, error) {
 	var err error
 	req := new(http.Request)
@@ -75,6 +80,9 @@ func requestData() (string, error) {
 	return string(data), err
 }
 
+// rcwrap is a thin wrapper that adapts an io.Reader into an io.ReadCloser
+// with a no-op Close method. This is used to satisfy the http.Request Body
+// requirement for POST requests constructed from a simple string buffer.
 type rcwrap struct {
 	r interface{}
 }

--- a/api/selichoje_test.go
+++ b/api/selichoje_test.go
@@ -5,22 +5,22 @@ import (
 )
 
 func TestParse(t *testing.T) {
-	const in = `Taxa Selic - Dados diários;Filtros aplicados: Data inicial: 07/04/2021 / Data final: 07/04/2021.;;;;;;;;;
+    const in = `Taxa Selic - Dados diários;Filtros aplicados: Data inicial: 07/04/2021 / Data final: 07/04/2021.;;;;;;;;;
 Data;Taxa (% a.a.);Fator diário;Financeiro (R$);Operações;Média;Mediana;Moda;Desvio padrão;Índice de curtose;
 07/04/2021;2,65;1,00010379;1.445.859.744.518,52;765;2,65;2,64;2,65;0,014;526,421;
 `
-	const expectedOut = "2.65"
-	out := getOnlySelic(in)
-	if out != expectedOut {
-		t.Errorf("expected '%s' got '%s'", expectedOut, out)
-	}
-	// Personal debugging
-	// data, err := requestData()
-	// if err != nil {
-	//     t.Error(err)
-	// }
-	// println("DATA:")
-	// println(data)
-	// println("PARSED:")
-	// println(getOnlySelic(data))
+    const expectedOut = "2.65"
+    out := getOnlySelic(in)
+    if (out != expectedOut) {
+        t.Errorf("expected '%s' got '%s'", expectedOut, out)
+    }
+    // Personal debugging
+    // data, err := requestData()
+    // if err != nil {
+    //     t.Error(err)
+    // }
+    // println("DATA:")
+    // println(data)
+    // println("PARSED:")
+    // println(getOnlySelic(data))
 }

--- a/api/selichoje_test.go
+++ b/api/selichoje_test.go
@@ -5,22 +5,22 @@ import (
 )
 
 func TestParse(t *testing.T) {
-    const in = `Taxa Selic - Dados diários;Filtros aplicados: Data inicial: 07/04/2021 / Data final: 07/04/2021.;;;;;;;;;
+	const in = `Taxa Selic - Dados diários;Filtros aplicados: Data inicial: 07/04/2021 / Data final: 07/04/2021.;;;;;;;;;
 Data;Taxa (% a.a.);Fator diário;Financeiro (R$);Operações;Média;Mediana;Moda;Desvio padrão;Índice de curtose;
 07/04/2021;2,65;1,00010379;1.445.859.744.518,52;765;2,65;2,64;2,65;0,014;526,421;
 `
-    const expectedOut = "2.65"
-    out := getOnlySelic(in)
-    if (out != expectedOut) {
-        t.Errorf("expected '%s' got '%s'", expectedOut, out)
-    }
-    // Personal debugging
-    // data, err := requestData()
-    // if err != nil {
-    //     t.Error(err)
-    // }
-    // println("DATA:")
-    // println(data)
-    // println("PARSED:")
-    // println(getOnlySelic(data))
+	const expectedOut = "2.65"
+	out := getOnlySelic(in)
+	if out != expectedOut {
+		t.Errorf("expected '%s' got '%s'", expectedOut, out)
+	}
+	// Personal debugging
+	// data, err := requestData()
+	// if err != nil {
+	//     t.Error(err)
+	// }
+	// println("DATA:")
+	// println(data)
+	// println("PARSED:")
+	// println(getOnlySelic(data))
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/lucasew/bcb-selic-hoje
 
 go 1.16
-
-require github.com/davecgh/go-spew v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/lucasew/bcb-selic-hoje
 
 go 1.16
+
+require github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
### 📝 Docs: Document API handler and internal logic

**Assumptions**
- The primary goal is to add docstrings to explain non-obvious details and the general flow in `api/selichoje.go`.
- Ghost code (commented-out blocks like the old `main` function) should be removed as per standard hygiene.
- No executable logic was modified.

**Alternatives Not Chosen**
- Using block comments (`/* */`) was avoided because standard Go convention requires line comments (`//`).
- Abstracting the `getOnlySelic` or `requestData` functions into a separate `pkg` directory was not done, to strictly preserve the existing Vercel deployment model.

**How To Pivot**
- If the details about the `07/04/2021` hardcoded date or lack of a timeout shouldn't be highlighted, simply remove the "Limitations" sections from the `requestData` docstring.

**Next Knobs**
- Look into fixing the hardcoded date in `requestData` (logic bug).
- Implement a structured timeout in `http.DefaultClient.Do(req)`.
- Replace deprecated `io/ioutil` with `io` and `os` in a separate janitor task.

---
*PR created automatically by Jules for task [4289160254726413660](https://jules.google.com/task/4289160254726413660) started by @lucasew*